### PR TITLE
Make sure that shared drush command folder is present

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -7,4 +7,4 @@ summary 'Drush Puppet Module'
 description 'A Puppet module to install and execute Drupal commands using Drush.'
 project_page 'http://github.com/erikwebb/erikwebb-drush'
 
-dependency 'rafaelfc/pear'
+dependency 'rafaelfc/pear', ">= 0"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,4 +37,19 @@ class drush(
     repository => 'pear.drush.org',
   }
 
+  file { "/usr/share/drush":
+    ensure => directory,
+    owner => root,
+    group => root,
+    mode => 755,
+  }
+
+  file {  "/usr/share/drush/commands":
+    require => File['/usr/share/drush'],
+    ensure => directory,
+    owner => root,
+    group => root,
+    mode => 755,
+  }
+
 }


### PR DESCRIPTION
What about including this in init.pp, like @tizzo has done at @zivtech:
https://github.com/zivtech/vagrant-development-vm/blob/master/puppet-modules/drush/manifests/init.pp#L29-L42

``` puppet
  file { "/usr/share/drush":
    ensure => directory,
    owner => root,
    group => root,
    mode => 755,
  }

  file {  "/usr/share/drush/commands":
    require => File['/usr/share/drush'],
    ensure => directory,
    owner => root,
    group => root,
    mode => 755,
  }
```

Still new to puppet, but I think the rationale is so that globally-installed drush commands can depend on the drush module without redeclaring:
https://github.com/zivtech/vagrant-development-vm/blob/master/puppet-modules/drushfetcher/manifests/init.pp#L1-L4
